### PR TITLE
Fixed a bug in StandardSynchronizer.cs

### DIFF
--- a/FileRecursive.cs
+++ b/FileRecursive.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.IO;
+static class FileHelper
+{
+    public static List<FileInfo> GetFilesRecursive(string b)
+    {
+        // 1.
+        // Store results in the file results list.
+        List<FileInfo> result = new List<FileInfo>();
+
+        // 2.
+        // Store a stack of our directories.
+        Stack<string> stack = new Stack<string>();
+
+        // 3.
+        // Add initial directory.
+        stack.Push(b);
+
+        // 4.
+        // Continue while there are directories to process
+        while (stack.Count > 0)
+        {
+            // A.
+            // Get top directory
+            string dir = stack.Pop();
+
+            try
+            {
+                // B
+                // Add all files at this directory to the result List.
+                
+                string[] tmpfiles = Directory.GetFiles(dir, "*.*");
+
+                for (int i = 0; i < tmpfiles.Length; i++)
+                {
+                    try
+                    {
+                        result.Add(new System.IO.FileInfo(tmpfiles[i]));
+                    }
+                    catch
+                    {
+
+                    }
+                }
+
+
+                // C
+                // Add all directories at this directory.
+                foreach (string dn in Directory.GetDirectories(dir))
+                {
+                    stack.Push(dn);
+                }
+            }
+            catch
+            {
+                // D
+                // Could not open the directory
+            }
+        }
+        return result;
+    }
+}

--- a/Notpod.csproj
+++ b/Notpod.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>9.0.30729</ProductVersion>
+    <ProductVersion>9.0.21022</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{BC5AD6BB-A60E-4FFC-8A9F-CB0B6E66E90D}</ProjectGuid>
     <OutputType>WinExe</OutputType>
@@ -106,7 +106,8 @@
     <OutputPath>bin\x64\Release x64\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Interop.iTunesLib">
+    <Reference Include="Interop.iTunesLib, Version=1.13.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>lib\Interop.iTunesLib.dll</HintPath>
     </Reference>
     <Reference Include="log4net">
@@ -115,9 +116,9 @@
     <Reference Include="nunit.framework">
       <HintPath>lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.mocks, Version=2.5.8.10295, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+    <Reference Include="Rhino.Mocks, Version=3.6.0.0, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>lib\nunit.mocks.dll</HintPath>
+      <HintPath>lib\Rhino.Mocks.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">
@@ -157,6 +158,7 @@
     <Compile Include="Device.cs" />
     <Compile Include="FileNameUtils.cs" />
     <Compile Include="FileNameUtilsTest.cs" />
+    <Compile Include="FileRecursive.cs" />
     <Compile Include="IConnectedDevicesManager.cs" />
     <Compile Include="DeviceConfiguration.cs" />
     <Compile Include="ISynchronizeForm.cs" />

--- a/StandardSynchronizer.cs
+++ b/StandardSynchronizer.cs
@@ -100,7 +100,7 @@ namespace Notpod
                 return;
             }
 
-            FileInfo[] files = di.GetFiles("*.*", SearchOption.AllDirectories);
+            FileInfo[] files = FileHelper.GetFilesRecursive(di.ToString()).ToArray();
 
             //Find correct synchronize pattern for the device.
             SyncPattern devicePattern = null;


### PR DESCRIPTION
DirectoryInfo.GetFiles() throws an error when it reaches a file with an illegal character in its name. I replaced it with a recursive file function (FileRecursive.cs) - by handling each individual file, the ones with problematic file names can be skipped over.
