### PR TITLE
Play order sync pattern from playlist

### DIFF
--- a/Resources/syncpatterns.xml
+++ b/Resources/syncpatterns.xml
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0"?>
+<?xml version="1.0"?>
 <SyncPatternCollection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
 	<SyncPatterns>	
+		<SyncPattern>
+	      <Identifier>playorder-flat</Identifier>
+	      <Name># Title - Artist</Name>
+	      <Pattern>%TRACKNUMINPLAYLIST% - %NAME% - %ARTIST%</Pattern>
+	      <Description>This pattern appends the track position according to playlist and then places the tracks in a flat folder.</Description>
+	      <!-- <CompilationsPattern>%TRACKNUMINPLAYLIST% - %NAME% - %ARTIST%</CompilationsPattern> -->
+	      <CompilationsPattern />
+	    </SyncPattern>
 		<SyncPattern>
 	      <Identifier>itunes-style</Identifier>
 	      <Name>Artist\Album\Track</Name>

--- a/SyncPatternTranslator.cs
+++ b/SyncPatternTranslator.cs
@@ -21,6 +21,7 @@ namespace Notpod
         /// %ALBUM%         = The album name
         /// %ALBUMINITIAL% 	= The album initial
         /// %NAME%          = The track name
+        /// %TRACKNUMINPLAYLIST% = Play order in playlist
         /// %TRACKNUMSPACE% = The track number with a trailing space
         /// %TRACKNUM%      = The track number (no trailing space)
         /// %DISCNUMDASH%   = The disc number with a trailing minus and space
@@ -46,6 +47,7 @@ namespace Notpod
 
                 patternstring = TranslateArtist(pattern, track, patternstring);
                 patternstring = TranslateArtistInitial(pattern, track, patternstring);
+                patternstring = TranslateTrackNumberInPlaylist(track, patternstring);
                 patternstring = TranslateAlbumArtist(pattern, track, patternstring);
                 patternstring = TranslateDiscNumber(track, patternstring);
                 patternstring = TranslateAlbum(track.Album, patternstring);
@@ -81,6 +83,22 @@ namespace Notpod
             patternstring = patternstring.Replace("%ARTISTINITIAL%", artist.Substring(0,1).ToUpper());
             return patternstring;
 		}
+
+        /// <summary>
+        /// Translate track playorder in playlist.
+        /// </summary>
+        /// <param name="track"></param>
+        /// <param name="patternstring"></param>
+        /// <returns></returns>
+        private static string TranslateTrackNumberInPlaylist(IITFileOrCDTrack track, string patternstring)
+        {
+            //%TRACKNUMINPLAYLIST%
+            patternstring = patternstring.Replace("%TRACKNUMINPLAYLIST%",
+                (track.PlayOrderIndex.ToString().Length >= 1 ?
+                    "00" + track.TrackNumber.ToString() : track.PlayOrderIndex.ToString())
+            );
+            return patternstring;
+        }
 
         /// <summary>
         /// Translate file extension.

--- a/SyncPatternTranslator.cs
+++ b/SyncPatternTranslator.cs
@@ -94,8 +94,8 @@ namespace Notpod
         {
             //%TRACKNUMINPLAYLIST%
             patternstring = patternstring.Replace("%TRACKNUMINPLAYLIST%",
-                (track.PlayOrderIndex.ToString().Length >= 1 ?
-                    "00" + track.TrackNumber.ToString() : track.PlayOrderIndex.ToString())
+                (track.PlayOrderIndex.ToString().Length == 1 ? "00" + track.PlayOrderIndex.ToString()
+                    : "0" + track.PlayOrderIndex.ToString())
             );
             return patternstring;
         }

--- a/SyncPatternTranslator.cs
+++ b/SyncPatternTranslator.cs
@@ -21,7 +21,7 @@ namespace Notpod
         /// %ALBUM%         = The album name
         /// %ALBUMINITIAL% 	= The album initial
         /// %NAME%          = The track name
-        /// %TRACKNUMINPLAYLIST% = Play order in playlist
+        /// %TRACKNUMINPLAYLIST% = Play order index from playlist with leading zero
         /// %TRACKNUMSPACE% = The track number with a trailing space
         /// %TRACKNUM%      = The track number (no trailing space)
         /// %DISCNUMDASH%   = The disc number with a trailing minus and space
@@ -85,7 +85,7 @@ namespace Notpod
 		}
 
         /// <summary>
-        /// Translate track playorder in playlist.
+        /// Translate track playorder index from playlist.
         /// </summary>
         /// <param name="track"></param>
         /// <param name="patternstring"></param>

--- a/SyncPatternTranslator.cs
+++ b/SyncPatternTranslator.cs
@@ -95,7 +95,8 @@ namespace Notpod
             //%TRACKNUMINPLAYLIST%
             patternstring = patternstring.Replace("%TRACKNUMINPLAYLIST%",
                 (track.PlayOrderIndex.ToString().Length == 1 ? "00" + track.PlayOrderIndex.ToString()
-                    : "0" + track.PlayOrderIndex.ToString())
+                    : track.PlayOrderIndex.ToString().Length == 2 ? "0" + track.PlayOrderIndex.ToString()
+                    : track.PlayOrderIndex.ToString())
             );
             return patternstring;
         }


### PR DESCRIPTION
I've added a new sync pattern that adds the PlayOrderIndex of the track from its playlist.

For example, if my playlist looks like this:
*Blue Skies - Artist1
*Home - Artist 2
*Without - Artist 3

...then the sync pattern would rename those to "001 - Blue Skies - Artist 1," "003 Without - Artist 3", and "002 Home - Artist 2". 

This is useful mainly for car steroes, where the order in which tracks are played depends on the file names (alphabetically/numerically) and cannot be changed on the fly. Adding the playing order from the iTunes playlist allows us to have some control over which song shows up first.

The pattern is %TRACKNUMINPLAYLIST%, and renames the files according to the _PlayOrderIndex_ - _Track_ - _Artist_. I've also added some leading zeroes to _PlayOrderIndex_ to preserve the order correctly. 

It seems to work, according to my requirements!
