### PR TITLE
Added support for playlists to be written on devices and export of tracks in playlist order

### DIFF
--- a/ConfigurationForm.Designer.cs
+++ b/ConfigurationForm.Designer.cs
@@ -40,9 +40,13 @@ namespace Notpod
             this.buttonBrowseMediaRoot = new System.Windows.Forms.Button();
             this.comboSyncPatterns = new System.Windows.Forms.ComboBox();
             this.buttonCreateUniqueFile = new System.Windows.Forms.Button();
+            this.buttonBrowseExportPlaylist = new System.Windows.Forms.Button();
+            this.buttonClearExportPlaylist = new System.Windows.Forms.Button();
             this.textMediaRoot = new System.Windows.Forms.TextBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.groupDeviceInformation = new System.Windows.Forms.GroupBox();
+            this.textExportPlaylist = new System.Windows.Forms.TextBox();
+            this.label6 = new System.Windows.Forms.Label();
             this.labelLinked = new System.Windows.Forms.Label();
             this.comboAssociatePlaylist = new System.Windows.Forms.ComboBox();
             this.label5 = new System.Windows.Forms.Label();
@@ -55,7 +59,7 @@ namespace Notpod
             this.textDeviceName = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
             this.listDevices = new System.Windows.Forms.ListView();
-            this.columnName = new System.Windows.Forms.ColumnHeader();
+            this.columnName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.buttonCancel = new System.Windows.Forms.Button();
             this.buttonOK = new System.Windows.Forms.Button();
             this.helpProvider = new System.Windows.Forms.HelpProvider();
@@ -177,6 +181,30 @@ namespace Notpod
             this.buttonCreateUniqueFile.UseVisualStyleBackColor = true;
             this.buttonCreateUniqueFile.Click += new System.EventHandler(this.buttonCreateUniqueFile_Click);
             // 
+            // buttonBrowseExportPlaylist
+            // 
+            this.buttonBrowseExportPlaylist.Enabled = false;
+            this.buttonBrowseExportPlaylist.Location = new System.Drawing.Point(358, 140);
+            this.buttonBrowseExportPlaylist.Name = "buttonBrowseExportPlaylist";
+            this.buttonBrowseExportPlaylist.Size = new System.Drawing.Size(65, 23);
+            this.buttonBrowseExportPlaylist.TabIndex = 17;
+            this.buttonBrowseExportPlaylist.Text = "Choose";
+            this.toolTip.SetToolTip(this.buttonBrowseExportPlaylist, "Browse for the folder if the device is already connected.");
+            this.buttonBrowseExportPlaylist.UseVisualStyleBackColor = true;
+            this.buttonBrowseExportPlaylist.Click += new System.EventHandler(this.buttonBrowseExportPlaylist_Click);
+            // 
+            // buttonClearExportPlaylist
+            // 
+            this.buttonClearExportPlaylist.Enabled = false;
+            this.buttonClearExportPlaylist.Location = new System.Drawing.Point(428, 140);
+            this.buttonClearExportPlaylist.Name = "buttonClearExportPlaylist";
+            this.buttonClearExportPlaylist.Size = new System.Drawing.Size(65, 23);
+            this.buttonClearExportPlaylist.TabIndex = 18;
+            this.buttonClearExportPlaylist.Text = "Clear";
+            this.toolTip.SetToolTip(this.buttonClearExportPlaylist, "Browse for the folder if the device is already connected.");
+            this.buttonClearExportPlaylist.UseVisualStyleBackColor = true;
+            this.buttonClearExportPlaylist.Click += new System.EventHandler(this.buttonClearExportPlaylist_Click);
+            // 
             // textMediaRoot
             // 
             this.textMediaRoot.Enabled = false;
@@ -194,13 +222,17 @@ namespace Notpod
             this.groupBox2.Controls.Add(this.listDevices);
             this.groupBox2.Location = new System.Drawing.Point(2, 104);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(512, 357);
+            this.groupBox2.Size = new System.Drawing.Size(512, 387);
             this.groupBox2.TabIndex = 1;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Devices";
             // 
             // groupDeviceInformation
             // 
+            this.groupDeviceInformation.Controls.Add(this.buttonClearExportPlaylist);
+            this.groupDeviceInformation.Controls.Add(this.buttonBrowseExportPlaylist);
+            this.groupDeviceInformation.Controls.Add(this.textExportPlaylist);
+            this.groupDeviceInformation.Controls.Add(this.label6);
             this.groupDeviceInformation.Controls.Add(this.labelLinked);
             this.groupDeviceInformation.Controls.Add(this.buttonCreateUniqueFile);
             this.groupDeviceInformation.Controls.Add(this.comboAssociatePlaylist);
@@ -218,10 +250,28 @@ namespace Notpod
             this.groupDeviceInformation.Controls.Add(this.label1);
             this.groupDeviceInformation.Location = new System.Drawing.Point(6, 182);
             this.groupDeviceInformation.Name = "groupDeviceInformation";
-            this.groupDeviceInformation.Size = new System.Drawing.Size(500, 167);
+            this.groupDeviceInformation.Size = new System.Drawing.Size(500, 199);
             this.groupDeviceInformation.TabIndex = 1;
             this.groupDeviceInformation.TabStop = false;
             this.groupDeviceInformation.Text = "Device information";
+            // 
+            // textExportPlaylist
+            // 
+            this.textExportPlaylist.Enabled = false;
+            this.textExportPlaylist.Location = new System.Drawing.Point(140, 142);
+            this.textExportPlaylist.Name = "textExportPlaylist";
+            this.textExportPlaylist.Size = new System.Drawing.Size(212, 20);
+            this.textExportPlaylist.TabIndex = 16;
+            this.textExportPlaylist.TextChanged += new System.EventHandler(this.textExportPlaylist_TextChanged);
+            // 
+            // label6
+            // 
+            this.label6.AutoSize = true;
+            this.label6.Location = new System.Drawing.Point(6, 146);
+            this.label6.Name = "label6";
+            this.label6.Size = new System.Drawing.Size(125, 13);
+            this.label6.TabIndex = 15;
+            this.label6.Text = "Create playlist on device:";
             // 
             // labelLinked
             // 
@@ -257,7 +307,7 @@ namespace Notpod
             // buttonDelete
             // 
             this.buttonDelete.Enabled = false;
-            this.buttonDelete.Location = new System.Drawing.Point(290, 138);
+            this.buttonDelete.Location = new System.Drawing.Point(290, 168);
             this.buttonDelete.Name = "buttonDelete";
             this.buttonDelete.Size = new System.Drawing.Size(84, 23);
             this.buttonDelete.TabIndex = 11;
@@ -268,7 +318,7 @@ namespace Notpod
             // buttonSave
             // 
             this.buttonSave.Enabled = false;
-            this.buttonSave.Location = new System.Drawing.Point(215, 138);
+            this.buttonSave.Location = new System.Drawing.Point(215, 168);
             this.buttonSave.Name = "buttonSave";
             this.buttonSave.Size = new System.Drawing.Size(75, 23);
             this.buttonSave.TabIndex = 10;
@@ -278,7 +328,7 @@ namespace Notpod
             // 
             // buttonNew
             // 
-            this.buttonNew.Location = new System.Drawing.Point(140, 138);
+            this.buttonNew.Location = new System.Drawing.Point(140, 168);
             this.buttonNew.Name = "buttonNew";
             this.buttonNew.Size = new System.Drawing.Size(75, 23);
             this.buttonNew.TabIndex = 9;
@@ -355,7 +405,7 @@ namespace Notpod
             // buttonCancel
             // 
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(439, 465);
+            this.buttonCancel.Location = new System.Drawing.Point(439, 497);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(75, 23);
             this.buttonCancel.TabIndex = 2;
@@ -364,7 +414,7 @@ namespace Notpod
             // buttonOK
             // 
             this.buttonOK.Enabled = false;
-            this.buttonOK.Location = new System.Drawing.Point(2, 465);
+            this.buttonOK.Location = new System.Drawing.Point(2, 497);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(75, 23);
             this.buttonOK.TabIndex = 3;
@@ -376,7 +426,7 @@ namespace Notpod
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.buttonCancel;
-            this.ClientSize = new System.Drawing.Size(518, 492);
+            this.ClientSize = new System.Drawing.Size(518, 525);
             this.Controls.Add(this.buttonOK);
             this.Controls.Add(this.buttonCancel);
             this.Controls.Add(this.groupBox2);
@@ -429,5 +479,10 @@ namespace Notpod
         private System.Windows.Forms.Button buttonCreateUniqueFile;
         private System.Windows.Forms.CheckBox checkWarnOnSystemDrives;
         private System.Windows.Forms.CheckBox checkConfirmMusicLocation;
+		
+        private System.Windows.Forms.Button buttonBrowseExportPlaylist;
+        private System.Windows.Forms.TextBox textExportPlaylist;
+        private System.Windows.Forms.Label label6;
+        private System.Windows.Forms.Button buttonClearExportPlaylist;
     }
 }

--- a/Device.cs
+++ b/Device.cs
@@ -8,71 +8,52 @@ namespace Notpod.Configuration12
 {
     public class Device
     {
-        private string name;
-
-        private string mediaRoot;
-
-        private string syncPattern;
-
-        private string recognizePattern;
-
-        private string playlist;
-
-        private ArrayList initialTracks = new ArrayList();
+        public Device() {
+            ExportPlaylist = new ExportPlaylist();
+            InitialTracks = new ArrayList();
+        }
 
         /// <summary>
         /// Accessor for name.
         /// </summary>
-        public string Name
-        {
-            get { return name; }
-            set { name = value; }
-        }
+        [XmlElement]
+        public string Name { get; set; }
         
         /// <summary>
         /// Accessor for mediaRoot.
         /// </summary>
-        public string MediaRoot
-        {
-            get { return mediaRoot; }
-            set { mediaRoot = value; }
-        }
+        [XmlElement]
+        public string MediaRoot { get; set; }
 
         /// <summary>
         /// Accessor for syncPattern.
         /// </summary>
-        public string SyncPattern
-        {
-            get { return syncPattern; }
-            set { syncPattern = value; }
-        }
+        [XmlElement]
+        public string SyncPattern { get; set; }
 
         /// <summary>
         /// Accessor for recognizePattern.
         /// </summary>
-        public string RecognizePattern
-        {
-            get { return recognizePattern; }
-            set { recognizePattern = value; }
-        }
+        [XmlElement]
+        public string RecognizePattern { get; set; }
 
         /// <summary>
         /// Accessor for playlist.
         /// </summary>
-        public string Playlist
-        {
-            get { return playlist; }
-            set { playlist = value; }
-        }
+        [XmlElement]
+        public string Playlist { get; set; }
+
+        /// <summary>
+        /// Accessor for ExportPlaylist.
+        /// </summary>
+        /// 
+        [XmlElement(typeof(ExportPlaylist))]
+        public ExportPlaylist ExportPlaylist { get; set; }
 
         /// <summary>
         /// Accessor for intialTracks.
         /// </summary>
         [XmlIgnore]
-        public ArrayList InitialTracks
-        {
-            get { return initialTracks; }
-            set { initialTracks = value; }
-        }
+        public ArrayList InitialTracks { get; set; }
     }
 }

--- a/DeviceConfiguration.cs
+++ b/DeviceConfiguration.cs
@@ -15,43 +15,24 @@ using System.ComponentModel;
 
 namespace Notpod.Configuration12
 {
-
+    [XmlRoot]
     public class DeviceConfiguration
     {
-
-        [XmlIgnore]
-        private ICollection<SyncPattern> syncPatterns = new List<SyncPattern>();
-
-        private ICollection<Device> devices = new List<Device>();
+        public DeviceConfiguration()
+        {
+            SyncPatterns = new List<SyncPattern>();
+            Devices = new List<Device>();
+        }
 
         /// <summary>
         /// Accessor for devices.
         /// </summary>
-        public Device[] Devices
-        {
-            get
-            {
-
-                Device[] devicesarr = new Device[devices.Count];
-                devices.CopyTo(devicesarr, 0);
-                return devicesarr;
-
-            }
-            set
-            {
-                devices.Clear();
-                foreach (Device d in value)
-                    devices.Add(d);
-
-            }
-        }
+        [XmlArray("Devices")]
+        [XmlArrayItem("Device")]
+        public List<Device> Devices { get; set; }
         
         [XmlIgnore]
-        public SyncPattern[] SyncPatterns {
-            
-            set { }
-            get { return new SyncPattern[0]; }
-        }
+        public List<SyncPattern> SyncPatterns { get; set; }
         
         /// <summary>
         /// Add a device.
@@ -59,7 +40,7 @@ namespace Notpod.Configuration12
         /// <param name="d">Device to add.</param>
         public void AddDevice(Device d)
         {
-            devices.Add(d);
+            Devices.Add(d);
         }
 
         /// <summary>
@@ -69,22 +50,13 @@ namespace Notpod.Configuration12
         /// <returns></returns>
         public bool RemoveDevice(Device d)
         {
-            return devices.Remove(d);
-        }
-
-        [XmlIgnore]
-        public ICollection<SyncPattern> SyncPattern {
-         
-            get { return syncPatterns; }
-            set { syncPatterns = value;}
+            return Devices.Remove(d);
         }
         
         public bool ContainsSyncPattern(SyncPattern sp) 
         {
-            foreach(SyncPattern existingPattern in syncPatterns) {
-                
-                if(existingPattern.Identifier == sp.Identifier) {
-                    
+            foreach(SyncPattern existingPattern in SyncPatterns) {
+                if (existingPattern.Identifier == sp.Identifier) {
                     return true;
                 }
             }

--- a/Docs/device-config.xml
+++ b/Docs/device-config.xml
@@ -22,6 +22,13 @@
       <Description>This pattern organizes all tracks in the root media folder of the device. All tracks from all artists are in one folder and names like this: Artist - Name.</Description>
       <CompilationsPattern />
     </SyncPattern>
+    <SyncPattern>
+      <Identifier>playlist-order</Identifier>
+      <Name>Playlist-Order Folder</Name>
+      <Pattern>%TRACKIDXSPACE%%ARTIST% - %NAME%</Pattern>
+      <Description>This pattern organizes all tracks in the root media folder of the device. All tracks from all artists are in one folder and names like this: Index Artist - Name.</Description>
+      <CompilationsPattern />
+    </SyncPattern>
   </SyncPatterns>
   <Devices>
     <Device>

--- a/ExportPlaylist.cs
+++ b/ExportPlaylist.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Collections;
+using System.Text;
+using System.Xml.Serialization;
+
+namespace Notpod.Configuration12
+{
+    public class ExportPlaylist
+    {
+        public ExportPlaylist()
+        {
+            Type = PlaylistType.None;
+        }
+
+        /// <summary>
+        /// Accessor for Type.
+        /// </summary>
+        [XmlElement("Type", typeof(PlaylistType))]
+        public PlaylistType Type { get; set; }
+
+        /// <summary>
+        /// Accessor for File.
+        /// </summary>
+        [XmlElement("File")]
+        public String File { get; set; }
+    }
+}

--- a/IConnectedDevicesManager.cs
+++ b/IConnectedDevicesManager.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Text;
 using System.IO;
 using Notpod.Configuration12;
+using System.Collections.Generic;
 
 namespace Notpod
 {
@@ -43,12 +44,12 @@ namespace Notpod
         /// </summary>
         /// <returns>A collection containing Device objects representing the 
         /// connected devices.</returns>
-        ICollection GetConnectedDevices();
+        HashSet<Device> GetConnectedDevices();
 
         /// <summary>
         /// Get the Hashtable containing all connected devices and what drives they are connected at.
         /// </summary>
         /// <returns>Hashtable containing all connected Devices.</returns>
-        Hashtable GetConnectedDevicesWithDrives();
+        Dictionary<String, HashSet<Device>> GetConnectedDevicesWithDrives();
     }
 }

--- a/IPlaylistWriter.cs
+++ b/IPlaylistWriter.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+
+using iTunesLib;
+
+namespace Notpod
+{
+    /// <summary>
+    /// Provides common functionality to playlist writer implementations.
+    /// </summary>
+    abstract class IPlaylistWriter
+    {
+        protected string fileName;
+        protected string playlist;
+
+        public IPlaylistWriter(string fileName, string playlist)
+        {
+            // Cleans up playlists with * characters in name.
+            this.fileName = fileName.Replace('*', '_');            
+            this.playlist = playlist;
+        }
+
+        /// <summary>
+        /// Writes the passed track to the current playlist file.
+        /// </summary>
+        /// <param name="trackName">The display name details for the track.</param>
+        /// <param name="track">Typed reference for the track, providing additional data.</param>
+        public abstract void WriteTrack( string trackName, IITTrack track );
+
+        /// <summary>
+        /// Closes the file handle for the playlist being written.
+        /// </summary>
+        public abstract void Close();
+
+        /// <summary>
+        /// Deletes the current playlist file from disk.
+        /// </summary>
+        public void Delete()
+        {
+            new FileInfo(fileName).Delete();
+        }
+    }
+}

--- a/M3UExtPlaylistWriter.cs
+++ b/M3UExtPlaylistWriter.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+using iTunesLib;
+
+namespace Notpod
+{
+    /// <summary>
+    /// Creates an M3U playlist in the Extended format. This format is described at
+    /// these URLs:
+    ///         http://hanna.pyxidis.org/tech/m3u.html
+    ///         http://en.wikipedia.org/wiki/M3U
+    ///         http://www.assistanttools.com/articles/m3u_playlist_format.shtml
+    /// </summary>
+    class M3UExtPlaylistWriter : IPlaylistWriter
+    {        
+        private StreamWriter _writer;
+        private string _thePlaylist;
+
+        private const string FILE_HEADER = "#EXTM3U";
+        private const string LINE_FORMAT_STRING = "{0}{1}, {2} - {3}";
+        private const string LINE_PREFIX = "#EXTINF:";
+
+        public M3UExtPlaylistWriter(string fileName, string playlist) : base(fileName, playlist)
+        {            
+            _thePlaylist = playlist;
+            _writer = new StreamWriter(fileName, false, System.Text.Encoding.GetEncoding("utf-8"));
+
+            /// File format requires a single line header
+            _writer.WriteLine(FILE_HEADER);
+        }
+
+        public override void WriteTrack(string trackName, IITTrack track)
+        {
+            /// Each track has two lines in the playlist file. The first contains
+            /// display info (seconds, name), plus the path/filename.
+            _writer.WriteLine(string.Format(LINE_FORMAT_STRING, LINE_PREFIX, track.Time.ToString(), track.Artist, track.Name));
+            _writer.WriteLine(trackName);
+        }
+
+        public override void Close()
+        {
+            _writer.Close();
+            _writer.Dispose();
+        }
+    }
+}

--- a/M3UPlaylistWriter.cs
+++ b/M3UPlaylistWriter.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+using iTunesLib;
+
+namespace Notpod
+{
+    /// <summary>
+    /// Generates basic M3U playlist files.
+    /// </summary>
+    class M3UPlaylistWriter : IPlaylistWriter
+    {
+        private StreamWriter writer;
+
+        public M3UPlaylistWriter(String fileName, string playlist ) : base(fileName, playlist)
+        {            
+            writer = new StreamWriter(fileName, false, System.Text.Encoding.GetEncoding("utf-8"));
+        }
+
+        public override void WriteTrack(string trackName, IITTrack track)
+        {
+            writer.WriteLine( trackName );
+        }
+
+        public override void Close()
+        {
+            writer.Close();
+        }
+    }
+}

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -425,12 +425,16 @@ namespace Notpod
         /// <param name="e"></param>
         protected override void OnClosing(CancelEventArgs e)
         {
-            Hashtable cd = connectedDevices.GetConnectedDevicesWithDrives();
+            Dictionary<String, HashSet<Device>> cd = connectedDevices.GetConnectedDevicesWithDrives();
             IDictionaryEnumerator cdenum = cd.GetEnumerator();
             while (cdenum.MoveNext())
             {
-                CDMEventArgs args = new CDMEventArgs(null, (Device)cdenum.Value);
-                OnDeviceDisconnect(this, (string)cdenum.Key, args);
+                HashSet<Device> devices = (HashSet<Device>)cdenum.Value;
+                foreach (Device device in devices)
+                {
+                    CDMEventArgs args = new CDMEventArgs(null, device);
+                    OnDeviceDisconnect(this, (string)cdenum.Key, args);
+                }
             }
 
             itunes = null;
@@ -551,66 +555,70 @@ namespace Notpod
         /// <returns>False if the user chooses to abort, true if all is good.</returns>
         private bool PerformDeviceCheck()
         {
-            Hashtable deviceinfo = connectedDevices.GetConnectedDevicesWithDrives();
-            IEnumerator keys = deviceinfo.Keys.GetEnumerator();
+            Dictionary<String,HashSet<Device>> deviceinfo = connectedDevices.GetConnectedDevicesWithDrives();
+            IDictionaryEnumerator keys = deviceinfo.GetEnumerator();
 
             while (keys.MoveNext())
             {
-                string drive = (string)keys.Current;
-                Device device = (Device)deviceinfo[keys.Current];
-                
-                DriveInfo driveInfo = new DriveInfo(drive);
-                if(driveInfo.DriveType == DriveType.Fixed) {
-                    
-                    l.Warn(String.Format("Detected fixed drive for {0} ({1}).", device.Name, drive));
-                    
-                    DialogResult choice = MessageBox.Show("The device '" + device.Name
-                        + "' is mapping to a fixed hard drive in your computer, not a removable storage. The drive currently associated"
-                        + " with this device is:\n\n\t" + drive + "\n\nIf you are sure this is "
-                        + "correct, you may continue. If you are unsure, or have misconfigured, "
-                        + "you should click 'Cancel' and make sure your device configuration is "
-                        + "correct before attempting a new synchronization.\n\nAre you sure you "
-                        + "want to continue?",
-                    "Warning", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
+                string drive = (string)keys.Key;
+                HashSet<Device> devices = (HashSet<Device>)keys.Value;
 
-                    if (choice == DialogResult.Cancel)
-                        return false;
-                }
-                
-                if (CheckIfSystemDrive(drive))
+                foreach (Device device in devices)
                 {
-                    l.Warn(String.Format("Detected possible system drive for {0} ({1}).", device.Name, drive));
-                    
-                    DialogResult choice = MessageBox.Show("The device '" + device.Name
-                        + "' looks like it's mapping to a system hard drive. The drive currently associated"
-                        + " with this device is:\n\n\t" + drive + "\n\nIf you are sure this is "
-                        + "correct, you may continue. If you are unsure, or have misconfigured, "
-                        + "you should click 'Cancel' and make sure your device configuration is "
-                        + "correct before attempting a new synchronization.\n\nAre you sure you "
-                        + "want to continue?",
-                    "Warning", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
+                    DriveInfo driveInfo = new DriveInfo(drive);
+                    if (driveInfo.DriveType == DriveType.Fixed)
+                    {
 
-                    if (choice == DialogResult.Cancel)
-                        return false;
-                
-                }
-                
-                if(CheckIfiTunesLibrary(drive))
-                {
-                    l.Warn(String.Format("Detected possible iTunes library location for {0} ({1}).", 
-                                         device.Name, drive));
-                    
-                    DialogResult choice = MessageBox.Show("The device '" + device.Name
-                        + "' looks like it's mapping to your local iTunes library. The drive currently associated"
-                        + " with this device is:\n\n\t" + drive + "\n\nIf you are sure this is "
-                        + "correct, you may continue. If you are unsure, or have misconfigured, "
-                        + "you should click 'Cancel' and make sure your device configuration is correct "
-                        + "before attempting a new synchronization.\n\nAre you sure you want to continue?",
-                    "Warning", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
+                        l.Warn(String.Format("Detected fixed drive for {0} ({1}).", device.Name, drive));
 
-                    if (choice == DialogResult.Cancel)
-                        return false;
-                    
+                        DialogResult choice = MessageBox.Show("The device '" + device.Name
+                            + "' is mapping to a fixed hard drive in your computer, not a removable storage. The drive currently associated"
+                            + " with this device is:\n\n\t" + drive + "\n\nIf you are sure this is "
+                            + "correct, you may continue. If you are unsure, or have misconfigured, "
+                            + "you should click 'Cancel' and make sure your device configuration is "
+                            + "correct before attempting a new synchronization.\n\nAre you sure you "
+                            + "want to continue?",
+                        "Warning", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
+
+                        if (choice == DialogResult.Cancel)
+                            return false;
+                    }
+
+                    if (CheckIfSystemDrive(drive))
+                    {
+                        l.Warn(String.Format("Detected possible system drive for {0} ({1}).", device.Name, drive));
+
+                        DialogResult choice = MessageBox.Show("The device '" + device.Name
+                            + "' looks like it's mapping to a system hard drive. The drive currently associated"
+                            + " with this device is:\n\n\t" + drive + "\n\nIf you are sure this is "
+                            + "correct, you may continue. If you are unsure, or have misconfigured, "
+                            + "you should click 'Cancel' and make sure your device configuration is "
+                            + "correct before attempting a new synchronization.\n\nAre you sure you "
+                            + "want to continue?",
+                        "Warning", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
+
+                        if (choice == DialogResult.Cancel)
+                            return false;
+
+                    }
+
+                    if (CheckIfiTunesLibrary(drive))
+                    {
+                        l.Warn(String.Format("Detected possible iTunes library location for {0} ({1}).",
+                                             device.Name, drive));
+
+                        DialogResult choice = MessageBox.Show("The device '" + device.Name
+                            + "' looks like it's mapping to your local iTunes library. The drive currently associated"
+                            + " with this device is:\n\n\t" + drive + "\n\nIf you are sure this is "
+                            + "correct, you may continue. If you are unsure, or have misconfigured, "
+                            + "you should click 'Cancel' and make sure your device configuration is correct "
+                            + "before attempting a new synchronization.\n\nAre you sure you want to continue?",
+                        "Warning", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning);
+
+                        if (choice == DialogResult.Cancel)
+                            return false;
+
+                    }
                 }
                 
             }
@@ -620,10 +628,8 @@ namespace Notpod
 
         public void PerformSynchronize()
         {
-
-
-            Hashtable deviceinfo = connectedDevices.GetConnectedDevicesWithDrives();
-            IEnumerator keys = deviceinfo.Keys.GetEnumerator();
+            Dictionary<String, HashSet<Device>> deviceinfo = connectedDevices.GetConnectedDevicesWithDrives();
+            IDictionaryEnumerator keys = deviceinfo.GetEnumerator();
             try
             {
                 // Create synchronizer and form.
@@ -632,8 +638,10 @@ namespace Notpod
 
                 while (keys.MoveNext())
                 {
-                    string drive = ((string)keys.Current).Substring(0, 3);
-                    Device device = (Device)deviceinfo[keys.Current];
+                    string drive = ((string)keys.Key).Substring(0, 3);
+
+                    HashSet<Device> devices = (HashSet<Device>)keys.Value;
+                    foreach (Device device in devices) {
 
                     if (configuration.ConfirmMusicLocation && !GetMusicLocationConfirmation(drive + device.MediaRoot))
                     {
@@ -659,6 +667,7 @@ namespace Notpod
                     synchronizer.SynchronizeCancelled += new SynchronizeCancelledEventHandler(OnSynchronizeCancelled);
                     synchronizer.SynchronizeDevice((IITUserPlaylist)playlist, drive, device);
 
+                }
                 }
                                 
             }

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -143,7 +143,7 @@ namespace Notpod
             }
             
             LoadSyncPatterns();
-            deviceConfiguration.SyncPattern = syncPatterns.SyncPatterns;
+            deviceConfiguration.SyncPatterns = syncPatterns.SyncPatterns;
                         
 
             if (!CreateITunesInstance())
@@ -632,8 +632,7 @@ namespace Notpod
 
                 while (keys.MoveNext())
                 {
-                    
-                    string drive = (string)keys.Current;
+                    string drive = ((string)keys.Current).Substring(0, 3);
                     Device device = (Device)deviceinfo[keys.Current];
 
                     if (configuration.ConfirmMusicLocation && !GetMusicLocationConfirmation(drive + device.MediaRoot))

--- a/Notpod.csproj
+++ b/Notpod.csproj
@@ -145,7 +145,12 @@
       <DependentUpon>AboutBox.cs</DependentUpon>
     </Compile>
     <Compile Include="DefaultITunesAppFactory.cs" />
+    <Compile Include="IPlaylistWriter.cs" />
     <Compile Include="ITunesAppFactory.cs" />
+    <Compile Include="ExportPlaylist.cs" />
+    <Compile Include="PlaylistType.cs" />
+    <Compile Include="M3UExtPlaylistWriter.cs" />
+    <Compile Include="M3UPlaylistWriter.cs" />
     <Compile Include="MainFormTest.cs" />
     <Compile Include="SyncPatternCollection.cs" />
     <Compile Include="Configuration.cs" />
@@ -178,6 +183,8 @@
     <Compile Include="MockFileOrCDTrack.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WPLPlaylistWriter.cs" />
+    <Compile Include="ZPLPlaylistWriter.cs" />
     <EmbeddedResource Include="AboutBox.resx">
       <DependentUpon>AboutBox.cs</DependentUpon>
       <SubType>Designer</SubType>

--- a/PlaylistType.cs
+++ b/PlaylistType.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Collections;
+using System.Text;
+using System.Xml.Serialization;
+
+namespace Notpod.Configuration12
+{
+    public enum PlaylistType {
+        [XmlEnum(Name = "None")]
+        None = 0,
+        [XmlEnum(Name = "M3U")]
+        M3U = 1,
+        [XmlEnum(Name = "EXT")]
+        EXT = 2,
+        [XmlEnum(Name = "WPL")]
+        WPL = 3,
+        [XmlEnum(Name = "ZPL")]
+        ZPL = 4
+    };
+}

--- a/Resources/syncpatterns.xml
+++ b/Resources/syncpatterns.xml
@@ -92,5 +92,12 @@
 	      <Description>This pattern organizes all tracks in the root media folder of the device. All tracks from all artists are in one folder and names like this: Artist - Name.</Description>
 	      <CompilationsPattern />
 	    </SyncPattern>
+	    <SyncPattern>
+	      <Identifier>playlist-order</Identifier>
+	      <Name>Playlist-Order Folder</Name>
+	      <Pattern>%TRACKIDXSPACE%%ARTIST% - %NAME%</Pattern>
+	      <Description>This pattern organizes all tracks in the root media folder of the device. All tracks from all artists are in one folder and names like this: Index Artist - Name.</Description>
+	      <CompilationsPattern />
+	    </SyncPattern>
 	</SyncPatterns>
   </SyncPatternCollection>

--- a/StandardSynchronizer.cs
+++ b/StandardSynchronizer.cs
@@ -104,7 +104,7 @@ namespace Notpod
 
             //Find correct synchronize pattern for the device.
             SyncPattern devicePattern = null;
-            foreach (SyncPattern sp in configuration.SyncPattern)
+            foreach (SyncPattern sp in configuration.SyncPatterns)
             {
                 if (sp.Identifier == device.SyncPattern)
                     devicePattern = sp;
@@ -131,10 +131,45 @@ namespace Notpod
 
             string deviceMediaRoot = drive + (device.MediaRoot.Length > 0 ? device.MediaRoot + "\\" : "");
 
+            string playlistFile = null;
+            if (device.ExportPlaylist != null && device.ExportPlaylist.File.Length > 0)
+            {
+                playlistFile = drive + device.ExportPlaylist.File;
+            }
+
+            IPlaylistWriter playlistWriter = null;
+
+            if (File.Exists(playlistFile))
+            {
+                File.Delete(playlistFile);
+            }
+
             try
             {
-                foreach (IITTrack track in playlist.Tracks)
+                // Create a new instance of one of the IPlaylistWriter implementations to
+                // handle the file's contents.
+                switch (device.ExportPlaylist.Type)
                 {
+                    case PlaylistType.M3U:
+                        playlistWriter = new M3UPlaylistWriter(playlistFile, playlist.Name);
+                        break;
+                    case PlaylistType.EXT:
+                        playlistWriter = new M3UExtPlaylistWriter(playlistFile, playlist.Name);
+                        break;
+                    case PlaylistType.WPL:
+                        playlistWriter = new WPLPlaylistWriter(playlistFile, playlist.Name);
+                        break;
+                    case PlaylistType.ZPL:
+                        playlistWriter = new ZPLPlaylistWriter(playlistFile, playlist.Name);
+                        break;
+                    default:
+                        break;
+                }
+          
+                for (int i = 1; i <= playlist.Tracks.Count ; i++)
+                {
+                    IITTrack track = playlist.Tracks.get_ItemByPlayOrder(i);
+
                     if (syncForm.GetOperationCancelled())
                     {
                         syncForm.SetCurrentStatus("Synchronization cancelled. 0 tracks added, 0 tracks removed.");
@@ -156,9 +191,9 @@ namespace Notpod
 
                     try
                     {
-                        pathOnDevice = SyncPatternTranslator.Translate(devicePattern, (IITFileOrCDTrack)addTrack);                        
+                        pathOnDevice = SyncPatternTranslator.Translate(devicePattern, (IITFileOrCDTrack)addTrack, i);
                     }
-                    catch (Exception ex)
+                    catch (Exception)
                     {
                         syncForm.AddLogText("An error occured while working with \"" + track.Artist + " - " + track.Name
                             + "\". This may be because the track has been deleted from disk. Look for an exclamation mark"
@@ -305,7 +340,7 @@ namespace Notpod
                 syncForm.SetMaxProgressValue(syncList.Count);
                 syncForm.SetProgressValue(0);
 
-                //Check for new track in the playlist which should be copied to the device
+                // Check for new track in the playlist which should be copied to the device
                 // NEW foreach: traverse synchronization list instead of playlist
                 // Thanks to Robert Grabowski.                
                 foreach (string filePath in syncList.Keys)
@@ -328,11 +363,28 @@ namespace Notpod
                     //Increase progress bar
                     syncForm.SetProgressValue(syncForm.GetProgressValue() + 1);
 
+                    //Continue with next track if it is not of a supported extension.
+                    //if (file.Extension != ".mp3" && file.Extension != ".acc" && file.Extension != ".m4p" && file.Extension != ".m4a")
+                    if (!extensions.Contains(Path.GetExtension(((IITFileOrCDTrack)track).Location)))
+                        continue;
+
                     string trackPath = filePath.Substring(deviceMediaRoot.Length); // hack: cut out media root
                     l.Debug("Checking for copy: " + filePath);
 
+                    string trackRelativePath = "";
+                    if (playlistFile != null)
+                        trackRelativePath = EvaluateRelativePath(Path.GetDirectoryName(playlistFile), filePath);
+
+                    if (trackRelativePath.StartsWith(".\\"))
+                        trackRelativePath = trackRelativePath.Substring(2);
+
                     if (File.Exists(filePath))
+                    {
+                        if (playlistWriter != null)
+                            playlistWriter.WriteTrack(trackRelativePath, track);
+
                         continue;
+                    }
 
                     try
                     {
@@ -342,7 +394,9 @@ namespace Notpod
                                                 
                         File.Copy(((IITFileOrCDTrack)track).Location, filePath, true);
                         File.SetAttributes(filePath, FileAttributes.Normal);
-
+                        
+                        if (playlistWriter != null)
+                            playlistWriter.WriteTrack(trackRelativePath, track);
 
                         syncForm.AddLogText(filePath + " copied successfully.", Color.Green);
 
@@ -362,9 +416,7 @@ namespace Notpod
                     tracksAdded++;
 
                 }
-            }
-            catch (MissingTrackException ex)
-            {
+            } catch (MissingTrackException ex) {
                 syncForm.SetCurrentStatus("");
                 String message = "You have a missing file in your library. Please remove the track '" + ex.Track.Artist + " - " + ex.Track.Name + "' and try again. I am sorry for the inconvenience.";
                 syncForm.AddLogText(message, Color.Red);
@@ -375,9 +427,7 @@ namespace Notpod
                 l.Error(message, ex);
 
                 return;
-            }
-            catch (Exception ex)
-            {
+            } catch (Exception ex) {
                 string message = "An error occured while copying new tracks: " + ex.Message;
                 syncForm.SetCurrentStatus("");
                 syncForm.AddLogText(message,
@@ -391,6 +441,12 @@ namespace Notpod
                 return;
             }
 
+            if (playlistWriter != null)
+            {
+                playlistWriter.Close();
+                playlistWriter = null;
+            }
+
             syncForm.SetCurrentStatus("Synchronization completed. " + tracksAdded
                 + " track(s) added, " + tracksRemoved + " track(s) removed.");
             syncForm.AddLogText("Completed. " + tracksAdded + " track(s) copied to your device.", Color.Green);
@@ -399,6 +455,58 @@ namespace Notpod
 
         }
 
+
+        /// <summary>
+        /// Resolve the relative path of a file to another file
+        /// </summary>
+        /// <param name="mainDirPath">The path of the file, which is absolute.</param>
+        /// <param name="absoluteFilePath">The path of the file, which should be made relative.</param>
+        private static string EvaluateRelativePath(string mainDirPath, string absoluteFilePath)
+        {
+            string[] firstPathParts = mainDirPath.Trim(Path.DirectorySeparatorChar).Split(Path.DirectorySeparatorChar);
+
+            string[] secondPathParts = absoluteFilePath.Trim(Path.DirectorySeparatorChar).Split(Path.DirectorySeparatorChar);
+
+            int sameCounter = 0;
+
+            for (int i = 0; i < Math.Min(firstPathParts.Length, secondPathParts.Length); i++)
+            {
+                if (!firstPathParts[i].ToLower().Equals(secondPathParts[i].ToLower()))
+                {
+                    break;
+                }
+                sameCounter++;
+            }
+
+            if (sameCounter == 0)
+            {
+                return absoluteFilePath;
+            }
+
+            string newPath = String.Empty;
+
+            for (int i = sameCounter; i < firstPathParts.Length; i++)
+            {
+                if (i > sameCounter)
+                {
+                    newPath += Path.DirectorySeparatorChar;
+                }
+                newPath += "..";
+            }
+
+            if (newPath.Length == 0)
+            {
+                newPath = ".";
+            }
+
+            for (int i = sameCounter; i < secondPathParts.Length; i++)
+            {
+                newPath += Path.DirectorySeparatorChar;
+                newPath += secondPathParts[i];
+            }
+
+            return newPath;
+        }
 
         /// <summary>
         /// Check if the necessary folders for the given track exists. If not, create them.

--- a/StandardSynchronizer.cs
+++ b/StandardSynchronizer.cs
@@ -166,7 +166,7 @@ namespace Notpod
                         break;
                 }
           
-                for (int i = 1; i <= playlist.Tracks.Count ; i++)
+                for (int i = 1; i <= playlist.Tracks.Count; i++)
                 {
                     IITTrack track = playlist.Tracks.get_ItemByPlayOrder(i);
 

--- a/SyncPatternCollection.cs
+++ b/SyncPatternCollection.cs
@@ -1,49 +1,24 @@
-﻿/*
- * Created by SharpDevelop.
- * User: Jaran
- * Date: 15.01.2012
- * Time: 12:22
- * 
- * To change this template use Tools | Options | Coding | Edit Standard Headers.
- */
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Xml.Serialization;
 
 namespace Notpod.Configuration12
 {
-    /// <summary>
-    /// Description of Class1.
-    /// </summary>
+    [XmlRoot]
     public class SyncPatternCollection
     {
-        
-        private ICollection<SyncPattern> syncPatterns = new List<SyncPattern>();
 
-        
-        /// <summary>
-        /// Accessor for syncPatterns.
-        /// </summary>
-        public SyncPattern[] SyncPatterns
+        public SyncPatternCollection()
         {
-            get
-            {
-                SyncPattern[] patterns = new SyncPattern[syncPatterns.Count];
-                syncPatterns.CopyTo(patterns, 0);
-                return patterns;
-            }
-            set
-            {
-                syncPatterns.Clear();
-                foreach (SyncPattern sp in value)
-                    syncPatterns.Add(sp);
-            }
+            SyncPatterns = new List<SyncPattern>();
         }
-        
-        public ICollection<SyncPattern> GetAsList() {
-            
-            return syncPatterns;
-        }
+
+        /// <summary>
+        /// Accessor for SyncPatterns.
+        /// </summary>
+        [XmlArray("SyncPatterns")]
+        [XmlArrayItem("SyncPattern")]
+        public List<SyncPattern> SyncPatterns { get; set; }
 
     }
 }

--- a/SyncPatternTranslator.cs
+++ b/SyncPatternTranslator.cs
@@ -23,13 +23,15 @@ namespace Notpod
         /// %NAME%          = The track name
         /// %TRACKNUMSPACE% = The track number with a trailing space
         /// %TRACKNUM%      = The track number (no trailing space)
+        /// %TRACKIDXSPACE% = The track index with a trailing space
+        /// %TRACKIDX%      = The track index (no trailing space)
         /// %DISCNUMDASH%   = The disc number with a trailing minus and space
         /// %DISCNUM%       = The disc number (no trailing space)
         /// </summary>
         /// <param name="pattern">SyncPattern to translate.</param>
         /// <param name="track">iTunes track containing track information.</param>
         /// <returns>A string representation of pattern and track.</returns>
-        public static string Translate(SyncPattern pattern, IITFileOrCDTrack track)
+        public static string Translate(SyncPattern pattern, IITFileOrCDTrack track, long lTrackIndex)
         {
             try
             {
@@ -41,7 +43,7 @@ namespace Notpod
                     l.Debug("track.Location is null!");
                     throw new MissingTrackException(track);
                 }
-
+ 
                 string patternstring = ((track.Compilation && pattern.CompilationsPattern != null && pattern.CompilationsPattern.Length > 0) ? pattern.CompilationsPattern : pattern.Pattern);
 
                 patternstring = TranslateArtist(pattern, track, patternstring);
@@ -51,6 +53,7 @@ namespace Notpod
                 patternstring = TranslateAlbum(track.Album, patternstring);
                 patternstring = TranslateName(track, patternstring);
                 patternstring = TranslateTrackNumber(track, patternstring);
+                patternstring = TranslateTrackIndex(track, patternstring, lTrackIndex);
                 patternstring = TranslateExtension(track, patternstring);
 
                 l.Debug("patternstring=" + patternstring);
@@ -134,6 +137,29 @@ namespace Notpod
                 patternstring = patternstring.Replace("%TRACKNUMSPACE%", "");
                 //%TRACKNUM%
                 patternstring = patternstring.Replace("%TRACKNUM%", "");
+            }
+            return patternstring;
+        }
+
+        private static string TranslateTrackIndex(IITFileOrCDTrack track, string patternstring, long lTrackIndex = 0L)
+        {
+            //Replace track number with a number only if the index is set
+            if (lTrackIndex != 0)
+            {
+                //%TRACKIDXSPACE%
+                patternstring = patternstring.Replace("%TRACKIDXSPACE%", 
+                lTrackIndex.ToString("000") + " ");
+
+                //%TRACKIDX%
+                patternstring = patternstring.Replace("%TRACKIDX%",
+                lTrackIndex.ToString("000"));
+            }
+            else //If there is no track index set for the track
+            {
+                //%TRACKIDXSPACE%
+                patternstring = patternstring.Replace("%TRACKIDXSPACE%", "");
+                //%TRACKIDX%
+                patternstring = patternstring.Replace("%TRACKIDX%", "");
             }
             return patternstring;
         }

--- a/SyncPatternTranslatorTest.cs
+++ b/SyncPatternTranslatorTest.cs
@@ -26,7 +26,7 @@ namespace Notpod.Test
             track.Location = "C:\\Music\\Coldplay\\X&Y\\Fix You.mp3";
 
             Assert.AreEqual("Coldplay\\X&Y\\Fix You.mp3", 
-                SyncPatternTranslator.Translate(pattern, track));
+                SyncPatternTranslator.Translate(pattern, track, 0));
         }
 
     }

--- a/WPLPlaylistWriter.cs
+++ b/WPLPlaylistWriter.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+using System.Xml;
+
+using iTunesLib;
+
+namespace Notpod
+{
+    /// <summary>
+    /// Generates playlist files in the WPL playlist format used by Windows Media Player.
+    /// </summary>
+    class WPLPlaylistWriter : IPlaylistWriter
+    {
+        private XmlWriter xmlWriter;
+
+        public WPLPlaylistWriter(string fileName, string playlist) : base(fileName, playlist)
+        {            
+            xmlWriter = new XmlTextWriter(fileName, System.Text.Encoding.GetEncoding("utf-8"));
+
+            xmlWriter.WriteRaw("<?wpl version=\"1.0\"?>\n");
+            xmlWriter.WriteStartElement("smil");
+            xmlWriter.WriteStartElement("head");
+            xmlWriter.WriteElementString("author", "");
+            xmlWriter.WriteElementString("title", playlist);
+            xmlWriter.WriteEndElement();
+            xmlWriter.WriteStartElement("body");
+            xmlWriter.WriteStartElement("seq");
+        }
+
+        public override void WriteTrack(string trackName, IITTrack track)
+        {
+            xmlWriter.WriteStartElement("media");
+            xmlWriter.WriteAttributeString("src", trackName);
+            xmlWriter.WriteEndElement();
+        }
+
+        public override void Close()
+        {
+            xmlWriter.WriteEndElement();
+            xmlWriter.WriteEndElement();
+            xmlWriter.WriteEndElement();
+            xmlWriter.Close();
+        }
+    }
+}

--- a/ZPLPlaylistWriter.cs
+++ b/ZPLPlaylistWriter.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.IO;
+using System.Xml;
+
+using iTunesLib;
+
+namespace Notpod
+{
+    /// <summary>
+    /// Generates playlist files in the ZPL playlist format used by Microsoft Zune Media Player.
+    /// </summary>
+    class ZPLPlaylistWriter : IPlaylistWriter
+    {
+        private XmlWriter xmlWriter;
+
+        public ZPLPlaylistWriter(string fileName, string playlist) : base(fileName, playlist)
+        {
+            XmlWriterSettings settings = new XmlWriterSettings();
+            settings.Indent = true;
+            settings.OmitXmlDeclaration = true;
+            settings.Encoding = System.Text.Encoding.GetEncoding("utf-8");
+
+            xmlWriter = XmlWriter.Create(fileName, settings);
+
+            xmlWriter.WriteRaw("<?zpl version=\"1.0\"?>\n");
+            xmlWriter.WriteStartElement("smil");
+            xmlWriter.WriteStartElement("head");
+
+            xmlWriter.WriteStartElement("meta");
+            xmlWriter.WriteAttributeString("name", "Generator");
+            xmlWriter.WriteAttributeString("content", "Zune -- 1.3.5728.0");
+            xmlWriter.WriteEndElement();
+
+            xmlWriter.WriteElementString("author", "");
+            xmlWriter.WriteElementString("title", playlist);
+            xmlWriter.WriteEndElement();
+            xmlWriter.WriteStartElement("body");
+            xmlWriter.WriteStartElement("seq");
+        }
+
+        public override void WriteTrack(string trackName, IITTrack track)
+        {
+            xmlWriter.WriteStartElement("media");
+            xmlWriter.WriteAttributeString("src", trackName);
+            xmlWriter.WriteEndElement();
+        }
+
+        public override void Close()
+        {
+            xmlWriter.WriteEndElement();
+            xmlWriter.WriteEndElement();
+            xmlWriter.WriteEndElement();
+            xmlWriter.Close();
+        }
+    }
+}

--- a/device-config.xml
+++ b/device-config.xml
@@ -22,6 +22,13 @@
       <Description>This pattern organizes all tracks in the root media folder of the device. All tracks from all artists are in one folder and names like this: Artist - Name.</Description>
       <CompilationsPattern />
     </SyncPattern>
+    <SyncPattern>
+      <Identifier>playlist-order</Identifier>
+      <Name>Playlist-Order Folder</Name>
+      <Pattern>%TRACKIDXSPACE%%ARTIST% - %NAME%</Pattern>
+      <Description>This pattern organizes all tracks in the root media folder of the device. All tracks from all artists are in one folder and names like this: Index Artist - Name.</Description>
+      <CompilationsPattern />
+    </SyncPattern>
   </SyncPatterns>
   <Devices>
     <Device>


### PR DESCRIPTION
I've merged my patches for the old iTunes Agent with the newest Notpod sources (see http://www.crea-doo.at/weblog/2011/01/05/itunesagent-1-3-4-patch-sync-more-than-one-folder-and-playlist-support/).
Two functionalities are added:
- Support for writing various playlists on the device (m3u, m3u extended, wpl, zpl)
- Export of tracks possible in the original playlist order (new sync pattern)

Furthermore I did a bit of clean up in the serializable classes for im-/exporting the xml settings.
